### PR TITLE
feat(api): add support to pass custom request header

### DIFF
--- a/xendit-java-lib/src/main/java/com/xendit/model/Balance.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/Balance.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
 import com.xendit.network.RequestResource;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,8 +30,7 @@ public class Balance {
    * @throws XenditException XenditException
    */
   public static Balance get() throws XenditException {
-    String url = String.format("%s%s", Xendit.getUrl(), "/balance");
-    return Xendit.requestClient.request(RequestResource.Method.GET, url, null, Balance.class);
+    return getBalance(new HashMap<>(), null);
   }
 
   /**
@@ -40,7 +41,30 @@ public class Balance {
    * @throws XenditException XenditException
    */
   public static Balance get(AccountType accountType) throws XenditException {
-    String url = String.format("%s%s%s", Xendit.getUrl(), "/balance?account_type=", accountType);
-    return Xendit.requestClient.request(RequestResource.Method.GET, url, null, Balance.class);
+    return getBalance(new HashMap<>(), accountType);
+  }
+
+  /**
+   * Get balance from your account based on given account type
+   *
+   * @param headers
+   * @param accountType The selected balance type
+   * @return Balance
+   * @throws XenditException XenditException
+   */
+  public static Balance get(Map<String, String> headers, AccountType accountType)
+      throws XenditException {
+    return getBalance(headers, accountType);
+  }
+
+  private static Balance getBalance(Map<String, String> headers, AccountType accountType)
+      throws XenditException {
+    String url = String.format("%s%s", Xendit.getUrl(), "/balance");
+    if (accountType != null) {
+      url = String.format("%s%s%s", url, "?account_type=", accountType);
+    }
+
+    return Xendit.requestClient.request(
+        RequestResource.Method.GET, url, headers, null, Balance.class);
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/BatchDisbursement.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/BatchDisbursement.java
@@ -43,13 +43,29 @@ public class BatchDisbursement {
    */
   public static BatchDisbursement create(String reference, BatchDisbursementItem[] disbursements)
       throws XenditException {
+    return create(new HashMap<>(), reference, disbursements);
+  }
+
+  /**
+   * Create a batch disbursement.
+   *
+   * @param headers
+   * @param reference ID of the batch disbursement in your system, used to reconcile disbursements
+   *     after they have been completed
+   * @param disbursements List of disbursements in the batch
+   * @return BatchDisbursement
+   * @throws XenditException XenditException
+   */
+  public static BatchDisbursement create(
+      Map<String, String> headers, String reference, BatchDisbursementItem[] disbursements)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/batch_disbursements");
     Map<String, Object> params = new HashMap<>();
     params.put("reference", reference);
     params.put("disbursements", disbursements);
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, BatchDisbursement.class);
+        RequestResource.Method.POST, url, headers, params, BatchDisbursement.class);
   }
 
   /**

--- a/xendit-java-lib/src/main/java/com/xendit/model/CardlessCredit.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CardlessCredit.java
@@ -74,8 +74,13 @@ public class CardlessCredit {
   }
 
   public static CardlessCredit create(Map<String, Object> params) throws XenditException {
+    return create(new HashMap<>(), params);
+  }
+
+  public static CardlessCredit create(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/cardless-credit");
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CardlessCredit.class);
+        RequestResource.Method.POST, url, headers, params, CardlessCredit.class);
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/CreditCard.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CreditCard.java
@@ -58,9 +58,22 @@ public class CreditCard {
    */
   public static CreditCardCharge createAuthorization(Map<String, Object> params)
       throws XenditException {
+    return createAuthorization(new HashMap<>(), params);
+  }
+
+  /**
+   * Create authorization with parameters in a HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-charge
+   * @return CreditCardCharge
+   * @throws XenditException XenditException
+   */
+  public static CreditCardCharge createAuthorization(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/credit_card_charges");
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CreditCardCharge.class);
+        RequestResource.Method.POST, url, headers, params, CreditCardCharge.class);
   }
 
   /**
@@ -107,9 +120,21 @@ public class CreditCard {
    * @throws XenditException XenditException
    */
   public static CreditCardCharge createCharge(Map<String, Object> params) throws XenditException {
+    return createCharge(new HashMap<>(), params);
+  }
+  /**
+   * Create charge with parameters in a HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-charge
+   * @return CreditCardCharge
+   * @throws XenditException XenditException
+   */
+  public static CreditCardCharge createCharge(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/credit_card_charges");
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CreditCardCharge.class);
+        RequestResource.Method.POST, url, headers, params, CreditCardCharge.class);
   }
 
   /**
@@ -121,6 +146,19 @@ public class CreditCard {
    */
   public static CreditCardReverseAuth reverseAuthorization(String chargeId, String externalId)
       throws XenditException {
+    return reverseAuthorization(new HashMap<>(), chargeId, externalId);
+  }
+
+  /**
+   * Reverse authorization by external ID
+   *
+   * @param headers
+   * @param externalId Charge reference
+   * @return CreditCardReverseAuth
+   * @throws XenditException XenditException
+   */
+  public static CreditCardReverseAuth reverseAuthorization(
+      Map<String, String> headers, String chargeId, String externalId) throws XenditException {
     String url =
         String.format(
             "%s%s%s%s", Xendit.getUrl(), "/credit_card_charges/", chargeId, "/auth_reversal");
@@ -128,7 +166,7 @@ public class CreditCard {
     params.put("external_id", externalId);
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CreditCardReverseAuth.class);
+        RequestResource.Method.POST, url, headers, params, CreditCardReverseAuth.class);
   }
 
   /**
@@ -141,13 +179,27 @@ public class CreditCard {
    */
   public static CreditCardCharge captureCharge(String chargeId, Number amount)
       throws XenditException {
+    return captureCharge(new HashMap<>(), chargeId, amount);
+  }
+
+  /**
+   * Capture a charge by charge ID
+   *
+   * @param headers
+   * @param chargeId Charge ID of authorization
+   * @param amount Amount to be captured. Can be up to amount of authorization but not more
+   * @return CreditCardCharge
+   * @throws XenditException XenditException
+   */
+  public static CreditCardCharge captureCharge(
+      Map<String, String> headers, String chargeId, Number amount) throws XenditException {
     Map<String, Object> params = new HashMap<>();
     params.put("amount", amount);
     String url =
         String.format("%s%s%s%s", Xendit.getUrl(), "/credit_card_charges/", chargeId, "/capture");
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CreditCardCharge.class);
+        RequestResource.Method.POST, url, headers, params, CreditCardCharge.class);
   }
 
   /**
@@ -174,6 +226,22 @@ public class CreditCard {
    */
   public static CreditCardRefund createRefund(String id, Number amount, String externalId)
       throws XenditException {
+    return createRefund(new HashMap<>(), id, amount, externalId);
+  }
+
+  /**
+   * Create a refund
+   *
+   * @param headers
+   * @param id Charge ID of the payment that will be refunded
+   * @param amount The amount to be refunded
+   * @param externalId A unique identifier of your choice. Max 64 characters.
+   * @return CreditCardRefund
+   * @throws XenditException XenditException
+   */
+  public static CreditCardRefund createRefund(
+      Map<String, String> headers, String id, Number amount, String externalId)
+      throws XenditException {
     Map<String, Object> params = new HashMap<>();
     params.put("amount", amount);
     params.put("external_id", externalId);
@@ -181,6 +249,6 @@ public class CreditCard {
         String.format("%s%s%s%s", Xendit.getUrl(), "/credit_card_charges/", id, "/refunds");
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, CreditCardRefund.class);
+        RequestResource.Method.POST, url, headers, params, CreditCardRefund.class);
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/Disbursement.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/Disbursement.java
@@ -61,7 +61,20 @@ public class Disbursement {
    * @throws XenditException
    */
   public static Disbursement create(Map<String, Object> params) throws XenditException {
-    return createRequest(params);
+    return createRequest(new HashMap<>(), params);
+  }
+
+  /**
+   * Create disbursement with all parameter as HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-disbursement.
+   * @return Disbursement
+   * @throws XenditException
+   */
+  public static Disbursement create(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
+    return createRequest(headers, params);
   }
 
   /**
@@ -94,7 +107,7 @@ public class Disbursement {
     params.put("account_number", accountNumber);
     params.put("description", description);
     params.put("amount", amount);
-    return createRequest(params);
+    return createRequest(new HashMap<>(), params);
   }
 
   /**
@@ -131,7 +144,7 @@ public class Disbursement {
     params.put("description", description);
     params.put("amount", amount);
     params.put("email_to", emailTo);
-    return createRequest(params);
+    return createRequest(new HashMap<>(), params);
   }
 
   /**
@@ -173,7 +186,7 @@ public class Disbursement {
     params.put("amount", amount);
     params.put("email_to", emailTo);
     params.put("email_cc", emailCc);
-    return createRequest(params);
+    return createRequest(new HashMap<>(), params);
   }
 
   /**
@@ -220,7 +233,7 @@ public class Disbursement {
     params.put("email_to", emailTo);
     params.put("email_cc", emailCc);
     params.put("email_bcc", emailBcc);
-    return createRequest(params);
+    return createRequest(new HashMap<>(), params);
   }
 
   /**
@@ -261,14 +274,15 @@ public class Disbursement {
     return Xendit.requestClient.request(RequestResource.Method.GET, url, null, Disbursement.class);
   }
 
-  private static Disbursement createRequest(Map<String, Object> params) throws XenditException {
+  private static Disbursement createRequest(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/disbursements");
     String amount = params.get("amount").toString();
 
     amountValidation(amount);
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, Disbursement.class);
+        RequestResource.Method.POST, url, headers, params, Disbursement.class);
   }
 
   private static void amountValidation(String amount) throws ParamException {

--- a/xendit-java-lib/src/main/java/com/xendit/model/EWalletPayment.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/EWalletPayment.java
@@ -84,7 +84,7 @@ public class EWalletPayment {
     params.put("ewallet_type", EWalletType.LINKAJA);
     params.put("callback_url", callbackUrl);
     params.put("redirect_url", redirectUrl);
-    return createPaymentRequest(params);
+    return createPaymentRequest(new HashMap<>(), params);
   }
 
   /**
@@ -104,7 +104,7 @@ public class EWalletPayment {
     params.put("amount", amount);
     params.put("phone", phone);
     params.put("ewallet_type", EWalletType.OVO);
-    return createPaymentRequest(params);
+    return createPaymentRequest(new HashMap<>(), params);
   }
 
   /**
@@ -136,7 +136,20 @@ public class EWalletPayment {
     params.put("callback_url", callbackUrl);
     params.put("redirect_url", redirectUrl);
     params.put("ewallet_type", EWalletType.DANA);
-    return createPaymentRequest(params);
+    return createPaymentRequest(new HashMap<>(), params);
+  }
+
+  /**
+   * Create new ewallet payment with all parameters as HashMap
+   *
+   * @param headers
+   * @param params mount end-customer will pay.
+   * @return EWalletPayment
+   * @throws XenditException XenditException
+   */
+  public static EWalletPayment createEWalletPayment(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
+    return createPaymentRequest(headers, params);
   }
 
   /**
@@ -172,14 +185,14 @@ public class EWalletPayment {
     }
   }
 
-  private static EWalletPayment createPaymentRequest(Map<String, Object> params)
-      throws XenditException {
+  private static EWalletPayment createPaymentRequest(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/ewallets");
     String amount = params.get("amount").toString();
 
     amountValidation(amount);
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, EWalletPayment.class);
+        RequestResource.Method.POST, url, headers, params, EWalletPayment.class);
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/EWalletPayment.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/EWalletPayment.java
@@ -140,19 +140,6 @@ public class EWalletPayment {
   }
 
   /**
-   * Create new ewallet payment with all parameters as HashMap
-   *
-   * @param headers
-   * @param params mount end-customer will pay.
-   * @return EWalletPayment
-   * @throws XenditException XenditException
-   */
-  public static EWalletPayment createEWalletPayment(
-      Map<String, String> headers, Map<String, Object> params) throws XenditException {
-    return createPaymentRequest(headers, params);
-  }
-
-  /**
    * @param externalId An ID of your choice. Often it is unique identifier like a phone number,
    *     email or transaction ID.
    * @param ewalletType The type of ewallet to be paid. Must be in capital letters.
@@ -185,7 +172,7 @@ public class EWalletPayment {
     }
   }
 
-  private static EWalletPayment createPaymentRequest(
+  public static EWalletPayment createPaymentRequest(
       Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/ewallets");
     String amount = params.get("amount").toString();

--- a/xendit-java-lib/src/main/java/com/xendit/model/FixedVirtualAccount.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/FixedVirtualAccount.java
@@ -72,7 +72,20 @@ public class FixedVirtualAccount {
    */
   public static FixedVirtualAccount createClosed(Map<String, Object> params)
       throws XenditException {
-    return create(params, true);
+    return create(new HashMap<>(), params, true);
+  }
+
+  /**
+   * Create closed VA with complete object
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-fixed-virtual-accounts.
+   * @return FixedVirtualAccount model.
+   * @throws XenditException
+   */
+  public static FixedVirtualAccount createClosed(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
+    return create(headers, params, true);
   }
 
   /**
@@ -94,7 +107,7 @@ public class FixedVirtualAccount {
     params.put("name", name);
     params.put("expected_amount", expectedAmount);
 
-    return create(params, true);
+    return create(new HashMap<>(), params, true);
   }
 
   /**
@@ -124,7 +137,7 @@ public class FixedVirtualAccount {
     params.put("expected_amount", expectedAmount);
     params.putAll(additionalParam);
 
-    return create(params, true);
+    return create(new HashMap<>(), params, true);
   }
 
   /**
@@ -135,7 +148,20 @@ public class FixedVirtualAccount {
    * @throws XenditException
    */
   public static FixedVirtualAccount createOpen(Map<String, Object> params) throws XenditException {
-    return create(params, false);
+    return create(new HashMap<>(), params, false);
+  }
+
+  /**
+   * Create closed VA with complete object
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-fixed-virtual-accounts.
+   * @return FixedVirtualAccount model.
+   * @throws XenditException
+   */
+  public static FixedVirtualAccount createOpen(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
+    return create(headers, params, false);
   }
 
   /**
@@ -155,7 +181,7 @@ public class FixedVirtualAccount {
     params.put("bank_code", bankCode);
     params.put("name", name);
 
-    return create(params, false);
+    return create(new HashMap<>(), params, false);
   }
 
   /**
@@ -179,7 +205,7 @@ public class FixedVirtualAccount {
     params.put("name", name);
     params.putAll(additionalParam);
 
-    return create(params, false);
+    return create(new HashMap<>(), params, false);
   }
 
   /**
@@ -235,7 +261,8 @@ public class FixedVirtualAccount {
         RequestResource.Method.GET, url, null, FixedVirtualAccountPayment.class);
   }
 
-  private static FixedVirtualAccount create(Map<String, Object> params, Boolean isClosed)
+  private static FixedVirtualAccount create(
+      Map<String, String> headers, Map<String, Object> params, Boolean isClosed)
       throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/callback_virtual_accounts");
 
@@ -246,6 +273,6 @@ public class FixedVirtualAccount {
     }
 
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, FixedVirtualAccount.class);
+        RequestResource.Method.POST, url, headers, params, FixedVirtualAccount.class);
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/Invoice.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/Invoice.java
@@ -156,8 +156,22 @@ public class Invoice {
    * @throws XenditException XenditException
    */
   public static Invoice create(Map<String, Object> params) throws XenditException {
+    return create(new HashMap<>(), params);
+  }
+
+  /**
+   * Create invoice with all parameters as HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-invoice.
+   * @return Invoice
+   * @throws XenditException XenditException
+   */
+  public static Invoice create(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/v2/invoices");
-    return Xendit.requestClient.request(RequestResource.Method.POST, url, params, Invoice.class);
+    return Xendit.requestClient.request(
+        RequestResource.Method.POST, url, headers, params, Invoice.class);
   }
 
   /**

--- a/xendit-java-lib/src/main/java/com/xendit/model/Payout.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/Payout.java
@@ -96,8 +96,22 @@ public class Payout {
    * @throws XenditException XenditException
    */
   public static Payout createPayout(Map<String, Object> params) throws XenditException {
+    return createPayout(new HashMap<>(), params);
+  }
+
+  /**
+   * Create payout with all parameters as HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-payout
+   * @return Payout
+   * @throws XenditException XenditException
+   */
+  public static Payout createPayout(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/payouts");
-    return Xendit.requestClient.request(RequestResource.Method.POST, url, params, Payout.class);
+    return Xendit.requestClient.request(
+        RequestResource.Method.POST, url, headers, params, Payout.class);
   }
 
   /**

--- a/xendit-java-lib/src/main/java/com/xendit/model/RecurringPayment.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/RecurringPayment.java
@@ -112,9 +112,22 @@ public class RecurringPayment {
    * @throws XenditException XenditException
    */
   public static RecurringPayment create(Map<String, Object> params) throws XenditException {
+    return create(new HashMap<>(), params);
+  }
+
+  /**
+   * Create recurring payment with given parameters as a HashMap object
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#create-a-recurring-payment
+   * @return RecurringPayment
+   * @throws XenditException XenditException
+   */
+  public static RecurringPayment create(Map<String, String> headers, Map<String, Object> params)
+      throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/recurring_payments");
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, RecurringPayment.class);
+        RequestResource.Method.POST, url, headers, params, RecurringPayment.class);
   }
 
   /**

--- a/xendit-java-lib/src/main/java/com/xendit/model/RetailOutlet.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/RetailOutlet.java
@@ -18,9 +18,22 @@ public class RetailOutlet {
    */
   public static FixedPaymentCode createFixedPaymentCode(Map<String, Object> params)
       throws XenditException {
+    return createFixedPaymentCode(new HashMap<>(), params);
+  }
+
+  /**
+   * Create fixed payment code with all parameters as HashMap
+   *
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#update-fixed-payment-code
+   * @return FixedPaymentCodeRetailOutlet
+   * @throws XenditException XenditException
+   */
+  public static FixedPaymentCode createFixedPaymentCode(
+      Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s", Xendit.getUrl(), "/fixed_payment_code");
     return Xendit.requestClient.request(
-        RequestResource.Method.POST, url, params, FixedPaymentCode.class);
+        RequestResource.Method.POST, url, headers, params, FixedPaymentCode.class);
   }
 
   /**
@@ -59,9 +72,22 @@ public class RetailOutlet {
    * @throws XenditException XenditException
    */
   public static FixedPaymentCode getFixedPaymentCode(String id) throws XenditException {
+    return getFixedPaymentCode(id, new HashMap<>());
+  }
+
+  /**
+   * Get fixed payment code by ID
+   *
+   * @param id ID of the fixed payment code to retrieve
+   * @param headers
+   * @return FixedPaymentCode
+   * @throws XenditException XenditException
+   */
+  public static FixedPaymentCode getFixedPaymentCode(String id, Map<String, String> headers)
+      throws XenditException {
     String url = String.format("%s%s%s", Xendit.getUrl(), "/fixed_payment_code/", id);
     return Xendit.requestClient.request(
-        RequestResource.Method.GET, url, null, FixedPaymentCode.class);
+        RequestResource.Method.GET, url, headers, null, FixedPaymentCode.class);
   }
 
   /**
@@ -74,9 +100,23 @@ public class RetailOutlet {
    */
   public static FixedPaymentCode updateFixedPaymentCode(String id, Map<String, Object> params)
       throws XenditException {
+    return updateFixedPaymentCode(id, new HashMap<>(), params);
+  }
+
+  /**
+   * Update fixed payment code by ID and with all parameters as HashMap
+   *
+   * @param id ID of the fixed payment code to be updated
+   * @param headers
+   * @param params listed here https://xendit.github.io/apireference/#update-fixed-payment-code
+   * @return FixedPaymentCode
+   * @throws XenditException XenditException
+   */
+  public static FixedPaymentCode updateFixedPaymentCode(
+      String id, Map<String, String> headers, Map<String, Object> params) throws XenditException {
     String url = String.format("%s%s%s", Xendit.getUrl(), "/fixed_payment_code/", id);
     return Xendit.requestClient.request(
-        RequestResource.Method.PATCH, url, params, FixedPaymentCode.class);
+        RequestResource.Method.PATCH, url, headers, params, FixedPaymentCode.class);
   }
 
   /**

--- a/xendit-java-lib/src/main/java/com/xendit/network/NetworkClient.java
+++ b/xendit-java-lib/src/main/java/com/xendit/network/NetworkClient.java
@@ -7,4 +7,12 @@ public interface NetworkClient {
   <T> T request(
       RequestResource.Method method, String url, Map<String, Object> params, Class<T> clazz)
       throws XenditException;
+
+  <T> T request(
+      RequestResource.Method method,
+      String url,
+      Map<String, String> headers,
+      Map<String, Object> params,
+      Class<T> clazz)
+      throws XenditException;
 }

--- a/xendit-java-lib/src/test/java/com/xendit/model/BalanceTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/BalanceTest.java
@@ -1,17 +1,21 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
 import com.xendit.network.BaseRequest;
 import com.xendit.network.RequestResource;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
 public class BalanceTest {
   private static String URL = String.format("%s%s", Xendit.getUrl(), "/balance");
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static Balance VALID_BALANCE = Balance.builder().balance(10000000).build();
 
   @Before
@@ -21,7 +25,8 @@ public class BalanceTest {
 
   @Test
   public void get_Success_IfNoGivenParam() throws XenditException {
-    when(Xendit.requestClient.request(RequestResource.Method.GET, URL, null, Balance.class))
+    when(Xendit.requestClient.request(
+            RequestResource.Method.GET, URL, HEADERS, null, Balance.class))
         .thenReturn(VALID_BALANCE);
     Balance balance = Balance.get();
     assertEquals(balance, VALID_BALANCE);
@@ -30,7 +35,8 @@ public class BalanceTest {
   @Test
   public void get_Success_IfGivenParam() throws XenditException {
     String url = String.format("%s%s", URL, "?account_type=CASH");
-    when(Xendit.requestClient.request(RequestResource.Method.GET, url, null, Balance.class))
+    when(Xendit.requestClient.request(
+            RequestResource.Method.GET, url, HEADERS, null, Balance.class))
         .thenReturn(VALID_BALANCE);
     Balance balance = Balance.get(Balance.AccountType.CASH);
     assertEquals(balance, VALID_BALANCE);

--- a/xendit-java-lib/src/test/java/com/xendit/model/BatchDisbursementTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/BatchDisbursementTest.java
@@ -1,7 +1,9 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
@@ -39,7 +41,7 @@ public class BatchDisbursementTest {
     String url = String.format("%s%s", Xendit.getUrl(), "/batch_disbursements");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, params, BatchDisbursement.class))
+            RequestResource.Method.POST, url, new HashMap<>(), params, BatchDisbursement.class))
         .thenReturn(VALID_BATCH);
     BatchDisbursement batchDisbursement = BatchDisbursement.create(TEST_REFERENCE, items);
 
@@ -54,7 +56,7 @@ public class BatchDisbursementTest {
     String url = String.format("%s%s", Xendit.getUrl(), "/batch_disbursements");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, params, BatchDisbursement.class))
+            RequestResource.Method.POST, url, new HashMap<>(), params, BatchDisbursement.class))
         .thenThrow(
             new XenditException("There was an error with the format submitted to the server."));
     BatchDisbursement.create(TEST_REFERENCE, null);

--- a/xendit-java-lib/src/test/java/com/xendit/model/CardlessCreditTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/CardlessCreditTest.java
@@ -1,7 +1,8 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
@@ -15,6 +16,7 @@ import org.junit.Test;
 public class CardlessCreditTest {
   private static String URL = String.format("%s%s", Xendit.getUrl(), "/cardless-credit");
   private static Map<String, Object> PARAMS = new HashMap<>();
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static CardlessCreditItem VALID_ITEM =
       CardlessCreditItem.builder()
           .id("123")
@@ -61,7 +63,7 @@ public class CardlessCreditTest {
   @Test
   public void create_Success_IfParamsAreValid() throws XenditException {
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CardlessCredit.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CardlessCredit.class))
         .thenReturn(VALID_CREDIT);
     CardlessCredit cardlessCredit = CardlessCredit.create(PARAMS);
 
@@ -73,7 +75,7 @@ public class CardlessCreditTest {
     PARAMS.clear();
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CardlessCredit.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CardlessCredit.class))
         .thenThrow(
             new XenditException("There was an error with the format submitted to the server."));
     CardlessCredit.create(PARAMS);

--- a/xendit-java-lib/src/test/java/com/xendit/model/CreditCardTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/CreditCardTest.java
@@ -1,7 +1,8 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
@@ -21,6 +22,7 @@ public class CreditCardTest {
   private static String TEST_AUTHENTICATION_ID = "test";
   private static String TEST_CARD_CVN = "123";
   private static Map<String, Object> PARAMS = new HashMap<>();
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static CreditCardCharge VALID_CHARGE = CreditCardCharge.builder().build();
 
   @Before
@@ -43,7 +45,7 @@ public class CreditCardTest {
     PARAMS.put("descriptor", "lorem ipsum");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CreditCardCharge.class))
         .thenReturn(VALID_CHARGE);
     CreditCardCharge creditCardCharge = CreditCard.createCharge(PARAMS);
 
@@ -56,7 +58,7 @@ public class CreditCardTest {
     PARAMS.put("external_id", "fake_id");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CreditCardCharge.class))
         .thenThrow(new XenditException("Token id is invalid"));
     CreditCard.createCharge(PARAMS);
   }
@@ -67,7 +69,7 @@ public class CreditCardTest {
     PARAMS.put("capture", false);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CreditCardCharge.class))
         .thenReturn(VALID_CHARGE);
     CreditCardCharge creditCardCharge = CreditCard.createAuthorization(PARAMS);
 
@@ -80,7 +82,7 @@ public class CreditCardTest {
     PARAMS.put("external_id", "fake_id");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, CreditCardCharge.class))
         .thenThrow(new XenditException("Token id is invalid"));
     CreditCard.createCharge(PARAMS);
   }
@@ -92,7 +94,7 @@ public class CreditCardTest {
     CreditCardReverseAuth creditCardReverseAuth = CreditCardReverseAuth.builder().build();
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardReverseAuth.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardReverseAuth.class))
         .thenReturn(creditCardReverseAuth);
     CreditCardReverseAuth result = CreditCard.reverseAuthorization(TEST_ID, TEST_EXTERNAL_ID);
 
@@ -105,7 +107,7 @@ public class CreditCardTest {
     PARAMS.put("external_id", TEST_EXTERNAL_ID);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardReverseAuth.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardReverseAuth.class))
         .thenThrow(new XenditException("Could not find credit card charge"));
     CreditCard.reverseAuthorization("fake_id", TEST_EXTERNAL_ID);
   }
@@ -116,7 +118,7 @@ public class CreditCardTest {
     PARAMS.put("amount", TEST_AMOUNT);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardCharge.class))
         .thenReturn(VALID_CHARGE);
     CreditCardCharge creditCardCharge = CreditCard.captureCharge(TEST_ID, TEST_AMOUNT);
 
@@ -129,7 +131,7 @@ public class CreditCardTest {
     PARAMS.put("amount", TEST_AMOUNT);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardCharge.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardCharge.class))
         .thenThrow(new XenditException("Could not find one credit card charge"));
     CreditCard.captureCharge("fake_id", TEST_AMOUNT);
   }
@@ -164,7 +166,7 @@ public class CreditCardTest {
     CreditCardRefund creditCardRefund = CreditCardRefund.builder().build();
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardRefund.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardRefund.class))
         .thenReturn(creditCardRefund);
     CreditCardRefund result = CreditCard.createRefund(TEST_ID, TEST_AMOUNT, TEST_EXTERNAL_ID);
 
@@ -178,7 +180,7 @@ public class CreditCardTest {
     PARAMS.put("external_id", TEST_EXTERNAL_ID);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, url, PARAMS, CreditCardRefund.class))
+            RequestResource.Method.POST, url, HEADERS, PARAMS, CreditCardRefund.class))
         .thenThrow(new XenditException("Refundable credit card charge not found"));
     CreditCard.createRefund("fake_id", TEST_AMOUNT, TEST_EXTERNAL_ID);
   }

--- a/xendit-java-lib/src/test/java/com/xendit/model/EWalletPaymentTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/EWalletPaymentTest.java
@@ -18,6 +18,7 @@ public class EWalletPaymentTest {
   private static String TEST_EXTERNAL_ID = "test_external_id";
   private static String TEST_PHONE = "081298498259";
   private static Map<String, Object> PARAMS = new HashMap<>();
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static EWalletPayment VALID_PAYMENT =
       EWalletPayment.builder().id(TEST_ID).externalId(TEST_EXTERNAL_ID).build();
 
@@ -46,7 +47,7 @@ public class EWalletPaymentTest {
     PARAMS.put("redirect_url", redirectUrl);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, EWalletPayment.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, EWalletPayment.class))
         .thenReturn(VALID_PAYMENT);
     EWalletPayment result =
         EWalletPayment.createLinkajaPayment(
@@ -61,7 +62,7 @@ public class EWalletPaymentTest {
     PARAMS.put("ewallet_type", EWalletPayment.EWalletType.OVO);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, EWalletPayment.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, EWalletPayment.class))
         .thenReturn(VALID_PAYMENT);
     EWalletPayment result = EWalletPayment.createOvoPayment(TEST_EXTERNAL_ID, 4444, TEST_PHONE);
 
@@ -81,7 +82,7 @@ public class EWalletPaymentTest {
     PARAMS.put("ewallet_type", EWalletPayment.EWalletType.DANA);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, EWalletPayment.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, EWalletPayment.class))
         .thenReturn(VALID_PAYMENT);
     EWalletPayment result =
         EWalletPayment.createDanaPayment(

--- a/xendit-java-lib/src/test/java/com/xendit/model/FixedVirtualAccountTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/FixedVirtualAccountTest.java
@@ -1,7 +1,9 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.enums.BankCode;
@@ -14,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FixedVirtualAccountTest {
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static Map<String, Object> PARAMS = new HashMap<>();
   private static String URL = String.format("%s%s", Xendit.getUrl(), "/callback_virtual_accounts");
   private static String TEST_ID = "test_id";
@@ -37,7 +40,7 @@ public class FixedVirtualAccountTest {
     PARAMS.put("expected_amount", 200000000);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedVirtualAccount.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedVirtualAccount.class))
         .thenReturn(VALID_ACCOUNT);
     FixedVirtualAccount fixedVirtualAccount = FixedVirtualAccount.createClosed(PARAMS);
 
@@ -49,7 +52,7 @@ public class FixedVirtualAccountTest {
     PARAMS.put("expected_amount", 50000000001L);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedVirtualAccount.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedVirtualAccount.class))
         .thenThrow(new XenditException("Maximum amount is 50000000000"));
     FixedVirtualAccount.createClosed(PARAMS);
   }
@@ -57,7 +60,7 @@ public class FixedVirtualAccountTest {
   @Test
   public void createOpen_Success_IfParamsAreValid() throws XenditException {
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedVirtualAccount.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedVirtualAccount.class))
         .thenReturn(VALID_ACCOUNT);
     FixedVirtualAccount fixedVirtualAccount = FixedVirtualAccount.createOpen(PARAMS);
 
@@ -69,7 +72,7 @@ public class FixedVirtualAccountTest {
     PARAMS.put("bank_code", "XYZ");
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedVirtualAccount.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedVirtualAccount.class))
         .thenThrow(new XenditException("That bank code is not currently supported"));
     FixedVirtualAccount.createOpen(PARAMS);
   }

--- a/xendit-java-lib/src/test/java/com/xendit/model/InvoiceTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/InvoiceTest.java
@@ -70,7 +70,8 @@ public class InvoiceTest {
   @Test(expected = XenditException.class)
   public void create_ThrowsException_IfInvalidParams() throws XenditException {
     Map<String, Object> params = new HashMap<>();
-    when(Xendit.requestClient.request(RequestResource.Method.POST, URL_V2, params, Invoice.class))
+    when(Xendit.requestClient.request(
+            RequestResource.Method.POST, URL_V2, new HashMap<>(), params, Invoice.class))
         .thenThrow(XenditException.class);
     Invoice.create(params);
   }

--- a/xendit-java-lib/src/test/java/com/xendit/model/PayoutTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/PayoutTest.java
@@ -21,6 +21,7 @@ public class PayoutTest {
   private static String TEST_STATUS = "ISSUED";
   private static String TEST_STATUS_VOIDED = "VOIDED";
   private static Map<String, Object> PARAMS = new HashMap<>();
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static Payout VALID_PAYOUT =
       Payout.builder()
           .id(TEST_ID)
@@ -47,7 +48,8 @@ public class PayoutTest {
 
   @Test
   public void createPayout_Success_IfParamsAreValid() throws XenditException {
-    when(Xendit.requestClient.request(RequestResource.Method.POST, URL, PARAMS, Payout.class))
+    when(Xendit.requestClient.request(
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, Payout.class))
         .thenReturn(VALID_PAYOUT);
     Payout payout = Payout.createPayout(PARAMS);
     assertEquals(payout, VALID_PAYOUT);
@@ -56,7 +58,8 @@ public class PayoutTest {
   @Test(expected = XenditException.class)
   public void createPayout_ThrowsException_IfParamsAreInvalid() throws XenditException {
     PARAMS.remove("amount");
-    when(Xendit.requestClient.request(RequestResource.Method.POST, URL, PARAMS, Payout.class))
+    when(Xendit.requestClient.request(
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, Payout.class))
         .thenThrow(
             new XenditException("There was an error with the format submitted to the server."));
     Payout.createPayout(PARAMS);

--- a/xendit-java-lib/src/test/java/com/xendit/model/RecurringPaymentTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/RecurringPaymentTest.java
@@ -1,7 +1,9 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
@@ -14,6 +16,7 @@ import org.junit.Test;
 
 public class RecurringPaymentTest {
   private static String URL = String.format("%s%s", Xendit.getUrl(), "/recurring_payments");
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static Map<String, Object> PARAMS = new HashMap<>();
   private static String TEST_ID = "5e2dd55ef8a4d24146f59775";
   private static String TEST_EXTERNAL_ID = "test_id";
@@ -47,7 +50,7 @@ public class RecurringPaymentTest {
   @Test
   public void create_Success_IfParamsAreValid() throws XenditException {
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, RecurringPayment.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, RecurringPayment.class))
         .thenReturn(VALID_PAYMENT);
     RecurringPayment recurringPayment = RecurringPayment.create(PARAMS);
     assertEquals(recurringPayment, VALID_PAYMENT);
@@ -57,7 +60,7 @@ public class RecurringPaymentTest {
   public void create_ThrowsException_IfParamsAreInvalid() throws XenditException {
     PARAMS.remove("external_id");
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, RecurringPayment.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, RecurringPayment.class))
         .thenThrow(
             new XenditException("There was an error with the format submitted to the server."));
     RecurringPayment.create(PARAMS);

--- a/xendit-java-lib/src/test/java/com/xendit/model/RetailOutletTest.java
+++ b/xendit-java-lib/src/test/java/com/xendit/model/RetailOutletTest.java
@@ -1,7 +1,8 @@
 package com.xendit.model;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.xendit.Xendit;
 import com.xendit.exception.XenditException;
@@ -14,6 +15,7 @@ import org.junit.Test;
 
 public class RetailOutletTest {
   private static final String URL = String.format("%s%s", Xendit.getUrl(), "/fixed_payment_code");
+  private static Map<String, String> HEADERS = new HashMap<>();
   private static Map<String, Object> PARAMS = new HashMap<>();
   private static String TEST_ID = "5e0cb0bbf4d38b20d5421b72";
   private static String TEST_EXTERNAL_ID = "test_id";
@@ -33,7 +35,7 @@ public class RetailOutletTest {
     PARAMS.put("expected_amount", 10000);
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedPaymentCode.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedPaymentCode.class))
         .thenReturn(VALID_FPC);
     FixedPaymentCode fpc = RetailOutlet.createFixedPaymentCode(PARAMS);
     assertEquals(fpc, VALID_FPC);
@@ -42,7 +44,7 @@ public class RetailOutletTest {
   @Test(expected = XenditException.class)
   public void createFixedPaymentCode_ThrowsException_IfInvalidParams() throws XenditException {
     when(Xendit.requestClient.request(
-            RequestResource.Method.POST, URL, PARAMS, FixedPaymentCode.class))
+            RequestResource.Method.POST, URL, HEADERS, PARAMS, FixedPaymentCode.class))
         .thenThrow(
             new XenditException("There was an error with the format submitted to the server."));
     RetailOutlet.createFixedPaymentCode(PARAMS);
@@ -52,7 +54,7 @@ public class RetailOutletTest {
   public void getFixedPaymentCode_Success_IfIdIsAvailable() throws XenditException {
     String url = String.format("%s%s%s", URL, "/", TEST_ID);
     when(Xendit.requestClient.request(
-            RequestResource.Method.GET, url, null, FixedPaymentCode.class))
+            RequestResource.Method.GET, url, HEADERS, null, FixedPaymentCode.class))
         .thenReturn(VALID_FPC);
     FixedPaymentCode fpc = RetailOutlet.getFixedPaymentCode(TEST_ID);
     assertEquals(fpc.getId(), VALID_FPC.getId());
@@ -62,7 +64,7 @@ public class RetailOutletTest {
   public void getFixedPaymentCode_ThrowsException_IfIdIsNotAvailable() throws XenditException {
     String url = String.format("%s%s%s", URL, "/", "fake_id");
     when(Xendit.requestClient.request(
-            RequestResource.Method.GET, url, null, FixedPaymentCode.class))
+            RequestResource.Method.GET, url, HEADERS, null, FixedPaymentCode.class))
         .thenThrow(new XenditException("Fixed payment code not found"));
     RetailOutlet.getFixedPaymentCode("fake_id");
   }
@@ -79,7 +81,7 @@ public class RetailOutletTest {
             .build();
 
     when(Xendit.requestClient.request(
-            RequestResource.Method.PATCH, url, PARAMS, FixedPaymentCode.class))
+            RequestResource.Method.PATCH, url, HEADERS, PARAMS, FixedPaymentCode.class))
         .thenReturn(result);
     FixedPaymentCode fpc = RetailOutlet.updateFixedPaymentCode(TEST_ID, PARAMS);
     assertEquals(fpc, result);
@@ -89,7 +91,7 @@ public class RetailOutletTest {
   public void updateFixedPaymentCode_ThrowsException_IfIdIsNotAvailable() throws XenditException {
     String url = String.format("%s%s%s", URL, "/", "fake_id");
     when(Xendit.requestClient.request(
-            RequestResource.Method.PATCH, url, PARAMS, FixedPaymentCode.class))
+            RequestResource.Method.PATCH, url, HEADERS, PARAMS, FixedPaymentCode.class))
         .thenThrow(new XenditException("Fixed payment code not found"));
     RetailOutlet.updateFixedPaymentCode("fake_id", PARAMS);
   }


### PR DESCRIPTION
1. Add support to pass custom request header. Resolves #52, Resolves #44, Resolves #43
2. Add `createEWalletPayment`. Resolves #17 