### PR TITLE
fix: make charge request params optional

### DIFF
--- a/xendit-java-lib/build.gradle
+++ b/xendit-java-lib/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.xendit'
-version '1.14.0'
+version '1.15.0'
 
 sourceCompatibility = 1.8
 

--- a/xendit-java-lib/src/main/java/com/xendit/model/CreditCard.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CreditCard.java
@@ -40,8 +40,8 @@ public class CreditCard {
     params.put("token_id", tokenId);
     params.put("external_id", externalId);
     params.put("amount", amount);
-    params.put("authentication_id", authenticationId);
-    params.put("card_cvn", cardCVN);
+    if (isNotEmpty(authenticationId)) params.put("authentication_id", authenticationId);
+    if (isNotEmpty(cardCVN)) params.put("card_cvn", cardCVN);
     params.put("capture", capture);
     String url = String.format("%s%s", Xendit.getUrl(), "/credit_card_charges");
 
@@ -103,9 +103,9 @@ public class CreditCard {
     params.put("token_id", tokenId);
     params.put("external_id", externalId);
     params.put("amount", amount);
-    params.put("authentication_id", authenticationId);
-    params.put("card_cvn", cardCVN);
-    params.put("descriptor", descriptor);
+    if (isNotEmpty(authenticationId)) params.put("authentication_id", authenticationId);
+    if (isNotEmpty(cardCVN)) params.put("card_cvn", cardCVN);
+    if (isNotEmpty(descriptor)) params.put("descriptor", descriptor);
     String url = String.format("%s%s", Xendit.getUrl(), "/credit_card_charges");
 
     return Xendit.requestClient.request(
@@ -250,5 +250,9 @@ public class CreditCard {
 
     return Xendit.requestClient.request(
         RequestResource.Method.POST, url, headers, params, CreditCardRefund.class);
+  }
+
+  private static boolean isNotEmpty(String param) {
+    return param != null && !"".equals(param);
   }
 }


### PR DESCRIPTION
Currently, some params for credit card charge are optional. Sending an empty string will throw 400 error.

Fixed by omitting empty fields when they are `null` or empty string.

![image](https://user-images.githubusercontent.com/3447315/128838880-8724a2d4-b93c-4c45-91f8-e73a4ed3b5c7.png)
