### PR TITLE
Java Library - Invoke HTTP Patch Lib for PATCH API

### DIFF
--- a/xendit-java-lib/build.gradle
+++ b/xendit-java-lib/build.gradle
@@ -19,7 +19,11 @@ repositories {
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.projectlombok:lombok:1.18.8'
+    // https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore
+    implementation 'org.apache.httpcomponents:httpcore:4.4.11'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
+    
     annotationProcessor 'org.projectlombok:lombok:1.18.8'
 
     compile group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.0'

--- a/xendit-java-lib/build.gradle
+++ b/xendit-java-lib/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.xendit'
-version '1.16.0'
+version '1.17.0'
 
 sourceCompatibility = 1.8
 

--- a/xendit-java-lib/src/main/java/com/xendit/network/BaseRequest.java
+++ b/xendit-java-lib/src/main/java/com/xendit/network/BaseRequest.java
@@ -17,6 +17,15 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 public class BaseRequest implements NetworkClient {
   private static final int DEFAULT_CONNECT_TIMEOUT = 60000;
@@ -112,17 +121,39 @@ public class BaseRequest implements NetworkClient {
     HttpURLConnection connection = null;
 
     try {
-      connection = createXenditConnection(url, apiKey, headers);
 
-      connection.setRequestMethod(method.getText());
+      if (method == RequestResource.Method.PATCH) {
+        CloseableHttpClient httpClient =
+            HttpClients.custom()
+                .setDefaultRequestConfig(
+                    RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+                .build();
+        HttpPatch request = new HttpPatch(url);
+        HttpEntity httpEntity = new ByteArrayEntity(jsonParams.getBytes("UTF-8"));
+        if (headers.get("Content-Type") == null) {
+          request.setHeader("Content-Type", "application/json");
+        }
+        for (Map.Entry<String, String> header : getHeaders(apiKey, headers).entrySet()) {
+          request.setHeader(header.getKey(), header.getValue());
+        }
 
-      if (method == RequestResource.Method.POST || method == RequestResource.Method.PATCH) {
-        connection.setDoOutput(true);
-        connection.setRequestProperty("Accept-Charset", "utf-8");
-        connection.setRequestProperty("Content-Type", "application/json;charset=utf-8");
-        OutputStream stream = connection.getOutputStream();
-        stream.write(jsonParams.getBytes("utf-8"));
-        stream.close();
+        request.setEntity(httpEntity);
+        CloseableHttpResponse response = httpClient.execute(request);
+        int responseCode = response.getStatusLine().getStatusCode();
+        String responseBody = EntityUtils.toString(response.getEntity());
+
+        return new XenditResponse(responseCode, responseBody);
+      } else {
+        connection = createXenditConnection(url, apiKey, headers);
+        connection.setRequestMethod(method.getText());
+        if (method == RequestResource.Method.POST) {
+          connection.setDoOutput(true);
+          connection.setRequestProperty("Accept-Charset", "utf-8");
+          connection.setRequestProperty("Content-Type", "application/json;charset=utf-8");
+          OutputStream stream = connection.getOutputStream();
+          stream.write(jsonParams.getBytes("utf-8"));
+          stream.close();
+        }
       }
 
       int responseCode = connection.getResponseCode();
@@ -136,6 +167,7 @@ public class BaseRequest implements NetworkClient {
 
       return new XenditResponse(responseCode, responseBody);
     } catch (IOException e) {
+      e.printStackTrace();
       throw new XenditException("Connection error");
     } finally {
       if (connection != null) {


### PR DESCRIPTION
Since HttpUrlConnection does not support PATCH Method, hence if any API using PATCH then only invoke this library : https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/dependency-info.html