### PR TITLE
feat: [DIGI-6402] add void_status as new field ewalletcharge

### DIFF
--- a/xendit-java-lib/build.gradle
+++ b/xendit-java-lib/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.xendit'
-version '1.20.2'
+version '1.20.3'
 
 sourceCompatibility = 1.8
 

--- a/xendit-java-lib/src/main/java/com/xendit/Xendit.java
+++ b/xendit-java-lib/src/main/java/com/xendit/Xendit.java
@@ -37,7 +37,7 @@ public class Xendit {
     }
 
     public String getVersion() {
-      return "1.20.2";
+      return "1.20.3";
     }
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/EWalletCharge.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/EWalletCharge.java
@@ -59,6 +59,9 @@ public class EWalletCharge {
   @SerializedName("voided_at")
   private String voidedAt;
 
+  @SerializedName("void_status")
+  private String voidStatus;
+
   @SerializedName("capture_now")
   private Boolean captureNow;
 


### PR DESCRIPTION
<img width="960" alt="image" src="https://user-images.githubusercontent.com/95068668/184857356-94f66b23-8be1-436c-ba68-6a95e81b7289.png">

`void_status` is a field that is currently returned by the eWallet Charge API but not available in the Java SDK at the moment. A merchant was enquiring about this field and we noticed this absence, hence we'd like to add this to the SDK.