### PR TITLE
Return installment object on Cards' Charge Response

### DIFF
--- a/xendit-java-lib/build.gradle
+++ b/xendit-java-lib/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.xendit'
-version '1.20.6'
+version '1.20.7'
 
 sourceCompatibility = 1.8
 

--- a/xendit-java-lib/src/main/java/com/xendit/Xendit.java
+++ b/xendit-java-lib/src/main/java/com/xendit/Xendit.java
@@ -37,7 +37,7 @@ public class Xendit {
     }
 
     public String getVersion() {
-      return "1.20.6";
+      return "1.20.7";
     }
   }
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/CreditCardCharge.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CreditCardCharge.java
@@ -1,6 +1,7 @@
 package com.xendit.model;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/xendit-java-lib/src/main/java/com/xendit/model/CreditCardCharge.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CreditCardCharge.java
@@ -59,4 +59,7 @@ public class CreditCardCharge {
 
   @SerializedName("failure_reason")
   private CreditCardEnum.FailureReason failureReason;
+
+  @SerializedName("installment")
+  private Map<String, Object> installment;
 }

--- a/xendit-java-lib/src/main/java/com/xendit/model/CreditCardEnum.java
+++ b/xendit-java-lib/src/main/java/com/xendit/model/CreditCardEnum.java
@@ -43,7 +43,8 @@ public class CreditCardEnum {
     INACTIVE_CARD,
     INVALID_CVN,
     PROCESSOR_ERROR,
-    BIN_BLOCK
+    BIN_BLOCK,
+    VALIDATION_ERROR
   }
 
   public enum RefundStatus {
@@ -53,6 +54,7 @@ public class CreditCardEnum {
 
   public enum RefundFailureReason {
     INSUFFICIENT_BALANCE,
-    REFUND_FAILED
+    REFUND_FAILED,
+    VALIDATION_ERROR
   }
 }


### PR DESCRIPTION
## Description
1. Return `installment ` object in Charge response -> [Thread](https://xendit.slack.com/archives/CGY42DC3T/p1663943050715509)
   It returned in our API response
2. Register `VALIDATION_ERROR` as one of the failure reason -> [Thread](https://xendit.slack.com/archives/CGY42DC3T/p1666009735146719)
   It returned in our API response, but not mapped in the library