### PR TITLE
Fix: Add null check for context parameter in XenditException constructor

### DIFF
--- a/xendit-java-lib/src/main/java/com/xendit/exception/XenditException.java
+++ b/xendit-java-lib/src/main/java/com/xendit/exception/XenditException.java
@@ -1,5 +1,6 @@
 package com.xendit.exception;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class XenditException extends Exception {
@@ -13,7 +14,7 @@ public class XenditException extends Exception {
   public XenditException(String message, String code, Map<String, Object> context) {
     super(message);
     this.code = code;
-    this.context = context;
+    this.context = context != null ? context : Collections.emptyMap();
   }
 
   public String getErrorCode() {


### PR DESCRIPTION
## Summary

This PR fixes a null pointer vulnerability in the `XenditException` class where the `context` parameter could be null, causing `NullPointerException` when client code attempts to iterate or access the context map.

## Changes

1. Added import for `java.util.Collections`
2. Modified the two-argument constructor to check if `context` is null and initialize it to `Collections.emptyMap()` if so

## Before

```java
public XenditException(String message, String code, Map<String, Object> context) {
    super(message);
    this.code = code;
    this.context = context;  // Could be null!
}
```

## After

```java
public XenditException(String message, String code, Map<String, Object> context) {
    super(message);
    this.code = code;
    this.context = context != null ? context : Collections.emptyMap();
}
```

## Benefits

- `getContext()` will never return null
- Client code can safely iterate over the context without null checks
- Follows Java best practices using `Collections.emptyMap()` for immutable empty collections

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.